### PR TITLE
Extended adc to use all pins, channels

### DIFF
--- a/include/asimple/adc.h
+++ b/include/asimple/adc.h
@@ -5,6 +5,11 @@
 #ifndef ADC_H_
 #define ADC_H_
 
+// TODO: needed to bring in am_hal_adc_slot_chan_e
+// (and adc.h depends on sysctrl.h)
+#include "am_hal_sysctrl.h"
+#include "am_hal_adc.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -18,15 +23,17 @@ struct adc
 {
 	void *handle;
 	uint8_t slots_configured;
+	am_hal_adc_slot_chan_e slot_channels[8]; // actually an am_hal_adc_slot_chan_e
 };
 
 /** Initializes the ADC.
  *
+ * (JV: OUTDATED?)
  * Initialization involves setting up timer 3 to trigger an interrupt every 1/8
  * of a second, and configuring slot 0 to get 14 bits of data from pin 16.
  *
- * This function allows initializing the following pins only:
- *  16, 29, 11
+ * Configures slots of the ADC to read from the pins specified
+ * Can specify up to 8 pins (8 ADC slots)
  *
  * @param[in,out] adc Pointer to the ADC object to initialize.
  * @param[in] pins Array of pin numbers to initialize.
@@ -34,19 +41,27 @@ struct adc
  */
 void adc_init(struct adc *adc, const uint8_t pins[], size_t size);
 
-/** Get a sample from the ADC.
+// As above, but specified in terms of ADC channels
+void adc_init_channels(struct adc *adc, const am_hal_adc_slot_chan_e channels[], size_t size);
+
+/** Get a batch of samples from the ADC.
  *
  * The sample and pins arrays must be the same size.
+ * Samples will be placed at locations corresponding to pins[]
  *
  * @param[in] adc Pointer to the ADC object to use.
- * @param[out] sample Data extracted from the ADC, if there is data available.
+ * @param[out] out_samples Data extracted from the ADC, if there is data available.
  * @param[in] pins The pins we want to get data from.
  * @param[in] size The number of pins we want to get data from.
  *
  * @returns True if there was data in the queue to extract, false otherwise.
  */
 bool adc_get_sample(
-	struct adc *adc, uint32_t sample[], const uint8_t pins[], size_t size);
+	struct adc *adc, uint32_t out_samples[], const uint8_t pins[], size_t size);
+
+// As above, but specified in terms of ADC channels
+bool adc_get_sample_channels(
+	struct adc *adc, uint32_t out_samples[], const am_hal_adc_slot_chan_e channels[], size_t size);
 
 /** Trigger the ADC to collect a sample.
  *


### PR DESCRIPTION
Old code should still work by calling
adc_init(..., pins, ...)
adc_get_sample(..., pins, ...)

Now all ADC pins should be supported

Can now also specify ADC channels (eg. AM_HAL_ADC_SLOT_CHSEL_BATT (Except differential pairs)